### PR TITLE
Update lisp.tex

### DIFF
--- a/lisp.tex
+++ b/lisp.tex
@@ -1464,7 +1464,7 @@ dotted-pairs אשר ה-car של כל אחד מהם הוא אטום, וה-cdr ש�
     ((null a-list) ; (i) a-list was exhausted.
       (error 'unbound-variable id))
     ((eq id (car (car a-list))) ; (ii) found in first dotted-pair
-      (car (cdr (car a-list)))) ; return value part of dotted pair
+      ((cdr (car a-list)))) ; return value part of dotted pair
     (t (lookup id (cdr a-list))))) ; (iii) otherwise, recursive call on remainder of a-list
 \end{KERNEL}
 גם בפונקציה lookup אנו רואים קריאה רקורסיבית עם cond המתפצל לשלושה מקרים: במקרה


### PR DESCRIPTION
This edit was dismissed in class after being called, but I still believe it is required. Below is why:

All edits to the a_list happen through bind:
(t ; both names and values are not empty
          (cons ; create new binding and prepend it to result of recursive call
            (cons (car names) (car values)) ; new DOTTED-PAIR defines single binding
            (bind (cdr names) (cdr values) a-list))))) ; recursive vall

notice that each pair in the a_list is dotted! Now look at the cdr usage examples at the end of the pdf:
(cdr ’(a.b)) ⇒ b
(cdr ’(a b)) ⇒ (b)

when running the PRIMITIVE cdr on a dotted pair, it returns the whole of the 2nd part in the dotted pair, not a list of it with nil.

If there is a flaw/misconception, I'd be happy to hear about it.